### PR TITLE
Switch to file-based metadata extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-# tiagolima
+# Denodo Metadata Reporter
+
+This repository contains a small Flask application that parses a Denodo
+configuration file and generates a Word report with extracted metadata.
+
+## Setup
+
+1. Install Python dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Run the application:
+   ```bash
+   python app.py
+   ```
+
+3. Open your browser at `http://localhost:5000` and upload a configuration
+   file. A Word document containing metadata information (such as heap memory
+   configuration) will be generated for download.
+
+The metadata extraction logic contains simple pattern matching for the heap
+memory setting. Adjust it to match your configuration format.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,30 @@
+from flask import Flask, render_template, request, send_file
+from src.metadata_reporter import fetch_denodo_metadata, generate_word_report
+import tempfile
+import os
+
+app = Flask(__name__)
+
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        uploaded_file = request.files.get('metadata_file')
+        if not uploaded_file:
+            return render_template('index.html', error='No file provided')
+
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            uploaded_file.save(tmp.name)
+            file_path = tmp.name
+
+        output_path = 'denodo_report.docx'
+        metadata = fetch_denodo_metadata(file_path)
+        generate_word_report(metadata, output_path)
+
+        os.remove(file_path)
+        return send_file(output_path, as_attachment=True)
+    return render_template('index.html')
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+python-docx

--- a/src/metadata_reporter.py
+++ b/src/metadata_reporter.py
@@ -1,0 +1,57 @@
+import os
+import re
+from typing import List, Dict
+
+from docx import Document
+
+
+def fetch_denodo_metadata(config_file: str) -> List[Dict[str, str]]:
+    """Parse a configuration file and extract metadata information.
+
+    Currently, this function only extracts the configured heap memory amount.
+    Extend the parsing logic as needed for other metrics.
+    """
+    metadata: List[Dict[str, str]] = []
+
+    with open(config_file, 'r', encoding='utf-8', errors='ignore') as f:
+        content = f.read()
+
+    heap_value = None
+
+    # Look for typical JVM heap settings like '-Xmx2G'
+    match = re.search(r'-Xmx([\d]+[mMgG])', content)
+    if not match:
+        # Also check for patterns like 'heap memory: 2048m'
+        match = re.search(r'heap\s*memory\s*[:=]?\s*([\d.]+\s*[kKmMgG][bB]?)', content)
+
+    if match:
+        heap_value = match.group(1)
+
+    metadata.append({
+        'database': 'configuration',
+        'view': 'heap_memory',
+        'description': heap_value or 'Unknown'
+    })
+
+    return metadata
+
+
+def generate_word_report(metadata: List[Dict[str, str]], output_path: str) -> None:
+    """Generate a Word report from metadata."""
+    document = Document()
+    document.add_heading("Denodo Metadata Report", level=1)
+
+    for item in metadata:
+        document.add_heading(f"{item['database']}.{item['view']}", level=2)
+        document.add_paragraph(item.get("description", "No description"))
+
+    document.save(output_path)
+
+
+if __name__ == "__main__":
+    config_file = os.getenv("DENODO_CONFIG_FILE", "config.txt")
+    output = "denodo_report.docx"
+
+    metadata = fetch_denodo_metadata(config_file)
+    generate_word_report(metadata, output)
+    print(f"Report saved to {output}")

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Denodo Metadata Report</title>
+</head>
+<body>
+    <h1>Denodo Metadata Report</h1>
+    <form method="post" enctype="multipart/form-data">
+        <label>Configuration File: <input type="file" name="metadata_file" required></label><br>
+        <button type="submit">Generate Report</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace host input with file upload in UI
- parse uploaded configuration for heap memory settings
- update README to describe new workflow
- clean requirements

## Testing
- `python -m py_compile app.py src/metadata_reporter.py`


------
https://chatgpt.com/codex/tasks/task_e_6846bbf6c7e8833395f8d2984a101765